### PR TITLE
fix(arns): update default CU URL, fix ARNS page

### DIFF
--- a/src/services/arns-api.ts
+++ b/src/services/arns-api.ts
@@ -105,7 +105,11 @@ export async function resolveArns(text: string) {
 export async function getAllRecords() {
   const result = await arIoCu.dryrun({
     process: import.meta.env.VITE_ARNS_AR_IO_REGISTRY,
-    tags: [{ name: "Action", value: "Records" }],
+     // NOTE: smaller page sizes are recommended
+    tags: [
+      { name: "Action", value: "Records" }, 
+      { name: 'Limit', value: "10000"}
+    ],
   })
 
   try {
@@ -113,12 +117,12 @@ export async function getAllRecords() {
       throw new Error(`No response from (get) Records`)
     }
 
-    const recordsMap = JSON.parse(result.Messages[0].Data) as Record<
-      string,
-      Omit<ArnsRecord, "name">
-    >
-
-    return recordsMap
+    const recordsArray = JSON.parse(result.Messages[0].Data).items as ArnsRecord[];
+    const recordsMap = recordsArray.reduce((acc: Record<string, ArnsRecord>, record) => {
+      acc[record.name] = record
+      return acc
+    }, {});
+    return recordsMap;
   } catch (err) {
     console.error(err)
     return []

--- a/src/services/arns-api.ts
+++ b/src/services/arns-api.ts
@@ -3,7 +3,7 @@ import { connect } from "@permaweb/aoconnect/browser"
 import { isArweaveId } from "@/utils/utils"
 
 const arIoCu = connect({
-  CU_URL: "https://cu.ar-io.dev",
+  CU_URL: "https://cu.ardrive.io",
 })
 
 export async function getOwnedDomains(entityId: string): Promise<string[]> {


### PR DESCRIPTION
`cu.ardrive.io` is for production traffic

Updated ArNS page:
<img width="1616" alt="image" src="https://github.com/user-attachments/assets/01a7c5df-8d27-453a-ab3f-e5b7c50050e0" />
