### PR TITLE
WIP: Swap page

### DIFF
--- a/src/app/swap/[slug]/ComputeResult.tsx
+++ b/src/app/swap/[slug]/ComputeResult.tsx
@@ -1,0 +1,104 @@
+"use client"
+
+import { Button, CircularProgress, Paper, Stack, Typography } from "@mui/material"
+import { result } from "@permaweb/aoconnect"
+import { MessageResult } from "@permaweb/aoconnect/dist/lib/result"
+import { Asterisk } from "@phosphor-icons/react"
+import React, { useCallback, useEffect, useState } from "react"
+
+import { FormattedDataBlock } from "@/components/FormattedDataBlock"
+import { getMessageById } from "@/services/messages-api"
+import { AoMessage } from "@/types"
+import { prettifyResult } from "@/utils/ao-utils"
+
+type ComputeResultProps = {
+  messageId: string
+  processId: string
+  autoCompute?: boolean
+  onComputedResult?: (result: MessageResult | null) => void
+}
+
+export function ComputeResult(props: ComputeResultProps) {
+  const { messageId, processId, autoCompute = false, onComputedResult } = props
+  const [content, setContent] = useState("")
+  const [loading, setLoading] = useState(false)
+
+  // undefined = loading
+  // null = not found
+  const [msg, setMsg] = React.useState<AoMessage | undefined | null>(undefined)
+
+  useEffect(() => {
+    if (!processId) {
+      setMsg(null)
+      return
+    }
+
+    getMessageById(processId).then(setMsg)
+  }, [processId])
+
+  const handleCompute = useCallback(async () => {
+    setLoading(true)
+    try {
+      const json = await result({
+        message: messageId,
+        process: processId,
+      })
+      onComputedResult?.(json)
+      setContent(JSON.stringify(prettifyResult(json), null, 2))
+    } catch (error) {
+      console.error(error)
+      setContent(String(error))
+    }
+    setTimeout(() => {
+      setLoading(false)
+    }, 500)
+  }, [messageId, processId])
+
+  useEffect(() => {
+    if (msg === undefined) return
+
+    if (autoCompute && msg) {
+      handleCompute()
+    }
+    if (autoCompute && msg === null) {
+      onComputedResult?.(null)
+    }
+  }, [msg, autoCompute])
+
+  return (
+    <Stack gap={1}>
+      <Stack direction="row" justifyContent="space-between" alignItems="center">
+        <Typography variant="subtitle2" color="text.secondary">
+          Compute Result
+        </Typography>
+        <Button
+          size="small"
+          color="secondary"
+          variant="contained"
+          onClick={handleCompute}
+          disabled={!msg || loading}
+          endIcon={
+            loading ? (
+              <CircularProgress size={12} color="inherit" />
+            ) : (
+              <Asterisk width={12} height={12} weight="bold" />
+            )
+          }
+        >
+          Compute
+        </Button>
+      </Stack>
+      <FormattedDataBlock
+        data={content}
+        placeholder={
+          msg === null
+            ? "There is no result to compute because the message was sent to a User."
+            : loading
+              ? "Loading..."
+              : "Click 'Compute' to get the result."
+        }
+        component={Paper}
+      />
+    </Stack>
+  )
+}

--- a/src/app/swap/[slug]/LinkedMessages.tsx
+++ b/src/app/swap/[slug]/LinkedMessages.tsx
@@ -1,0 +1,53 @@
+import React, { memo } from "react"
+
+import { EntityMessagesTable } from "@/app/entity/[slug]/EntityMessagesTable"
+import { getMessageById, getLinkedMessages } from "@/services/messages-api"
+import { AoMessage } from "@/types"
+
+type Props = {
+  pushedFor?: string
+  messageId: string
+  onCountReady?: (count: number) => void
+  onDataReady?: (data: AoMessage[]) => void
+}
+
+function BaseLinkedMessages(props: Props) {
+  const { pushedFor, messageId, onCountReady, onDataReady } = props
+
+  const pageSize = 25
+
+  return (
+    <EntityMessagesTable
+      pageSize={pageSize}
+      fetchFunction={async (offset, ascending, sortField, lastRecord) => {
+        let [count, records] = await getLinkedMessages(
+          pageSize,
+          lastRecord?.cursor,
+          ascending,
+          pushedFor || messageId,
+        )
+
+        if (pushedFor) {
+          records = records.filter((msg) => msg.id !== messageId)
+          const pushedForMsg = await getMessageById(pushedFor)
+          if (pushedForMsg) {
+            records.push(pushedForMsg as AoMessage)
+          }
+        }
+
+        if (count !== undefined && onCountReady) {
+          onCountReady(count)
+        }
+
+        if (onDataReady) {
+          onDataReady(records)
+        }
+
+        return records
+      }}
+    />
+  )
+}
+
+// TODO FIXME
+export const LinkedMessages = memo(BaseLinkedMessages)

--- a/src/app/swap/[slug]/MessageData.tsx
+++ b/src/app/swap/[slug]/MessageData.tsx
@@ -1,0 +1,32 @@
+import { Paper, Stack, Typography } from "@mui/material"
+import React, { useEffect, useState } from "react"
+
+import { FormattedDataBlock } from "@/components/FormattedDataBlock"
+import { AoMessage } from "@/types"
+
+export function MessageData(props: { message: AoMessage }) {
+  const { message } = props
+
+  const [data, setData] = useState<string>("")
+
+  useEffect(() => {
+    if (!message) return
+
+    if (message.type === "Checkpoint") {
+      setData("Message too long")
+    } else {
+      fetch(`https://arweave.net/${message.id}`)
+        .then((res) => res.text())
+        .then(setData)
+    }
+  }, [message])
+
+  return (
+    <Stack gap={1} justifyContent="stretch">
+      <Typography variant="subtitle2" color="text.secondary">
+        Data
+      </Typography>
+      <FormattedDataBlock data={data} isEvalMessage={message.action === "Eval"} component={Paper} />
+    </Stack>
+  )
+}

--- a/src/app/swap/[slug]/ResultingMessages.tsx
+++ b/src/app/swap/[slug]/ResultingMessages.tsx
@@ -1,0 +1,64 @@
+import { MessageResult } from "@permaweb/aoconnect/dist/lib/result"
+import React, { memo, useMemo } from "react"
+
+import { EntityMessagesTable } from "@/app/entity/[slug]/EntityMessagesTable"
+import { LoadingSkeletons } from "@/components/LoadingSkeletons"
+import { getResultingMessages } from "@/services/messages-api"
+import { AoMessage } from "@/types"
+import { parseAoMessageFromCU } from "@/utils/arweave-utils"
+
+type Props = {
+  message: AoMessage
+  onCountReady?: (count: number) => void
+  onDataReady?: (data: AoMessage[]) => void
+  computeResult: MessageResult | null | undefined
+}
+
+function BaseResultingMessages(props: Props) {
+  const { message, onCountReady, onDataReady, computeResult } = props
+
+  const pageSize = 100
+
+  const computeResultMsgs = useMemo(
+    () =>
+      computeResult && computeResult.Messages
+        ? computeResult.Messages.map(parseAoMessageFromCU)
+        : [],
+    [computeResult],
+  )
+
+  // undefined = loading
+  // null = not found
+  if (computeResult === undefined) return <LoadingSkeletons />
+
+  return (
+    <EntityMessagesTable
+      pageSize={pageSize}
+      fetchFunction={async (offset, ascending, sortField, lastRecord) => {
+        let [count, records] = await getResultingMessages(
+          pageSize,
+          lastRecord?.cursor,
+          ascending,
+          message?.tags["Pushed-For"] || message.id,
+          message.to,
+          computeResultMsgs.map((msg) => msg.tags["Reference"] || msg.tags["Ref_"]),
+          !!computeResultMsgs[0]?.tags["Ref_"],
+        )
+
+        if (count !== undefined && onCountReady) {
+          onCountReady(count)
+        }
+
+        if (onDataReady) {
+          // onDataReady(records)
+          onDataReady([])
+        }
+
+        return records
+      }}
+    />
+  )
+}
+
+// TODO FIXME
+export const ResultingMessages = memo(BaseResultingMessages)

--- a/src/app/swap/[slug]/SwapPage.tsx
+++ b/src/app/swap/[slug]/SwapPage.tsx
@@ -139,7 +139,7 @@ export function SwapPage() {
       const [, [CreditNoticeTokenInMessage]] = await getResultingMessages(
         1,
         "",
-        false,
+        true,
         "",
         transferInMessage.to,
         [CreditNoticeTokenInRef],
@@ -187,7 +187,7 @@ export function SwapPage() {
 
       // Get transfer message ID from graph using message ref
       const transferRef = getTagValue(transferOut.Tags, "Reference")
-      const [, [transferOutMessage]] = await getResultingMessages(1, "", false, "", lpProcessId, [
+      const [, [transferOutMessage]] = await getResultingMessages(1, "", true, "", lpProcessId, [
         transferRef,
       ])
       const {

--- a/src/app/swap/[slug]/SwapPage.tsx
+++ b/src/app/swap/[slug]/SwapPage.tsx
@@ -1,0 +1,146 @@
+import { Box, CircularProgress, Paper, Stack, Tabs, Tooltip, Typography } from "@mui/material"
+
+import Grid2 from "@mui/material/Unstable_Grid2/Grid2"
+import { MessageResult } from "@permaweb/aoconnect/dist/lib/result"
+import { useQuery } from "@tanstack/react-query"
+import React, { useCallback, useEffect, useMemo, useState } from "react"
+
+import { Navigate, useParams, useSearchParams } from "react-router-dom"
+
+import { ComputeResult } from "./ComputeResult"
+import { LinkedMessages } from "./LinkedMessages"
+import { MessageData } from "./MessageData"
+import { ResultingMessages } from "./ResultingMessages"
+import { EntityBlock } from "@/components/EntityBlock"
+import { ChartDataItem, Graph } from "@/components/Graph"
+import { IdBlock } from "@/components/IdBlock"
+
+import { LoadingSkeletons } from "@/components/LoadingSkeletons"
+import { SectionInfo } from "@/components/SectionInfo"
+import { SectionInfoWithChip } from "@/components/SectionInfoWithChip"
+import { Subheading } from "@/components/Subheading"
+import { TabWithCount } from "@/components/TabWithCount"
+import { TagsSection } from "@/components/TagsSection"
+
+import { getMessageById, getResultingMessages } from "@/services/messages-api"
+import { AoMessage, Tag } from "@/types"
+import { truncateId } from "@/utils/data-utils"
+import { formatFullDate, formatRelative } from "@/utils/date-utils"
+
+import { formatNumber } from "@/utils/number-utils"
+import { isArweaveId } from "@/utils/utils"
+import { result } from "@permaweb/aoconnect"
+import { prettifyResult } from "@/utils/ao-utils"
+
+const defaultTab = "resulting"
+
+interface Swap {
+  originalTransaction: string
+  tokenIn: string
+  tokenOut: string
+  initiator: string
+  amm: string
+  quantityIn: string
+}
+
+export function SwapPage() {
+  const { messageId = "" } = useParams()
+
+  const [swapLoading, setSwapLoading] = useState<boolean>(true)
+  const [swapData, setSwapData] = useState<Swap | undefined>(undefined)
+
+  const isValidId = useMemo(() => isArweaveId(String(messageId)), [messageId])
+
+  const {
+    data: message,
+    isLoading,
+    error,
+  } = useQuery({
+    enabled: Boolean(messageId) && isValidId,
+    queryKey: ["message", messageId],
+    queryFn: () => getMessageById(messageId),
+  })
+
+  const getSwap = async (originalMessage: AoMessage) => {
+    try {
+      // If original message has no Swap tag => not a swap
+      if (originalMessage.tags["X-Action"] !== "Swap")
+        throw new Error("Message does not initiate a swap")
+      // Get resulting messages from original message
+      const { Messages } = await result({
+        message: originalMessage.id,
+        process: originalMessage.to,
+      })
+      // Get resulting Credit Notice message from the token in to the AMM
+      const creditNotice = Messages.find((m) => {
+        const { Tags } = m
+        const requiredTags = new Map([
+          ["Action", "Credit-Notice"],
+          ["X-Action", "Swap"],
+        ])
+        return [...requiredTags].every(([key, value]) =>
+          Tags.some(({ name, value: tagValue }: Tag) => name === key && tagValue === value),
+        )
+      })
+      // If no credit notice message is sent to the AMM => not a swap
+      if (!creditNotice) throw new Error("No credit notice message sent to AMM")
+      // Get credit notice message ID from graph using message ref
+      const { value: creditNoticeRef } = creditNotice.Tags.find(
+        (tag: Tag) => tag.name === "Reference",
+      )
+      const [count, [creditNoticeMessage]] = await getResultingMessages(1, "", true, "", originalMessage.to, [creditNoticeRef])
+      console.log(`getResultingRecords creditNoticeMessage:`, creditNoticeMessage)
+      const {
+        tags: {
+          Quantity: quantityIn,
+        },
+        to: ammProcessId,
+      } = creditNoticeMessage
+
+      const data: Swap = {
+        originalTransaction: originalMessage.id,
+        tokenIn: originalMessage.to,
+        tokenOut: "",
+        initiator: originalMessage.from,
+        amm: ammProcessId,
+        quantityIn,
+      }
+
+      setSwapData(data)
+    } catch (e) {
+      console.error(e)
+    }
+  }
+
+  useEffect(() => {
+    if (!!message) {
+      getSwap(message)
+    }
+  }, [message])
+
+  if (isLoading) {
+    return <LoadingSkeletons />
+  }
+
+  if (!isValidId || error || !message) {
+    return (
+      <Stack component="main" gap={4} paddingY={4}>
+        <Typography>{error?.message || "Message not found."}</Typography>
+      </Stack>
+    )
+  }
+
+  const { from, type, blockHeight, ingestedAt, to, systemTags, userTags } = message
+
+  if (type === "Process") {
+    return <Navigate to={`/entity/${messageId}`} />
+  }
+
+  return (
+    <React.Fragment key={messageId}>
+      <Stack component="main" gap={6} paddingY={4}>
+        <Subheading type="SWAP" value={<IdBlock label={messageId} />} />
+      </Stack>
+    </React.Fragment>
+  )
+}

--- a/src/app/swap/[slug]/SwapPage.tsx
+++ b/src/app/swap/[slug]/SwapPage.tsx
@@ -31,6 +31,8 @@ import { formatNumber } from "@/utils/number-utils"
 import { isArweaveId } from "@/utils/utils"
 import { result } from "@permaweb/aoconnect"
 import { prettifyResult } from "@/utils/ao-utils"
+import { TokenAmountSection } from "@/components/TokenAmountSection"
+import { useTokenInfo } from "@/hooks/useTokenInfo"
 
 const defaultTab = "resulting"
 
@@ -54,6 +56,9 @@ export function SwapPage() {
 
   const [swapLoading, setSwapLoading] = useState<boolean>(true)
   const [swapData, setSwapData] = useState<Swap | undefined>(undefined)
+
+  const tokenInInfo = useTokenInfo(swapData?.tokenIn ?? "")
+  const tokenOutInfo = useTokenInfo(swapData?.tokenOut ?? "")
 
   const isValidId = useMemo(() => isArweaveId(String(messageId)), [messageId])
 
@@ -208,14 +213,8 @@ export function SwapPage() {
           <SectionInfo title="AMM" value={<EntityBlock entityId={amm} />} />
           <SectionInfo title="Token In" value={<EntityBlock entityId={tokenIn} />} />
           <SectionInfo title="Token Out" value={<EntityBlock entityId={tokenOut} />} />
-          {/* <SectionInfo
-            title="Quantity In"
-            value={
-              <Tooltip title={formatFullDate(ingestedAt)}>
-                <span>{formatNumber(quantityIn)}</span>
-              </Tooltip>
-            }
-          /> */}
+          <TokenAmountSection tokenInfo={tokenInInfo} amount={quantityIn} label="Quantity In" />
+          <TokenAmountSection tokenInfo={tokenOutInfo} amount={quantityOut} label="Quantity Out" />
           <SectionInfo
             title="Block Height"
             value={

--- a/src/app/swap/[slug]/SwapPage.tsx
+++ b/src/app/swap/[slug]/SwapPage.tsx
@@ -1,7 +1,7 @@
 import { Stack, Tooltip, Typography } from "@mui/material"
 
 import { useQuery } from "@tanstack/react-query"
-import React, { useEffect, useMemo, useState } from "react"
+import React, { Fragment, useEffect, useMemo, useState } from "react"
 
 import { useParams } from "react-router-dom"
 
@@ -139,7 +139,7 @@ export function SwapPage() {
       const [, [CreditNoticeTokenInMessage]] = await getResultingMessages(
         1,
         "",
-        true,
+        false,
         "",
         transferInMessage.to,
         [CreditNoticeTokenInRef],
@@ -187,7 +187,7 @@ export function SwapPage() {
 
       // Get transfer message ID from graph using message ref
       const transferRef = getTagValue(transferOut.Tags, "Reference")
-      const [, [transferOutMessage]] = await getResultingMessages(1, "", true, "", lpProcessId, [
+      const [, [transferOutMessage]] = await getResultingMessages(1, "", false, "", lpProcessId, [
         transferRef,
       ])
       const {
@@ -244,9 +244,6 @@ export function SwapPage() {
   const {
     blockHeight,
     ingestedAt,
-    transferInMessageId,
-    creditNoticeMessageId,
-    transferOutMessageId,
     tokenIn,
     tokenOut,
     initiator,
@@ -260,6 +257,9 @@ export function SwapPage() {
     <React.Fragment key={messageId}>
       <Stack component="main" gap={6} paddingY={4}>
         <Subheading type="SWAP" value={<IdBlock label={messageId} />} />
+        {!!failingMessage ? (
+          <SectionInfo title="Failing Message" value={<EntityBlock entityId={failingMessage.id} />} />
+        ) : null}
         <Stack gap={4}>
           <SectionInfo title="Swapper" value={<EntityBlock entityId={initiator} />} />
           <SectionInfo title="AMM Factory" value={<EntityBlock entityId={ammFactory} />} />
@@ -275,18 +275,22 @@ export function SwapPage() {
             }
           />
           <TokenAmountSection tokenInfo={tokenInInfo} amount={quantityIn} label="Quantity In" />
-          <TokenAmountSection
-            tokenInfo={tokenOutInfo}
-            amount={swapData?.quantityOut ?? "0"}
-            label="Quantity Out"
-            loading={!swapData?.quantityOut}
-          />
-          <TokenAmountSection
-            tokenInfo={tokenInInfo}
-            amount={swapData?.totalFee ?? "0"}
-            label="Total Fee"
-            loading={!swapData?.totalFee}
-          />
+          {!failingMessage ? (
+            <Fragment>
+              <TokenAmountSection
+                tokenInfo={tokenOutInfo}
+                amount={swapData?.quantityOut ?? "0"}
+                label="Quantity Out"
+                loading={!swapData?.quantityOut}
+              />
+              <TokenAmountSection
+                tokenInfo={tokenInInfo}
+                amount={swapData?.totalFee ?? "0"}
+                label="Total Fee"
+                loading={!swapData?.totalFee}
+              />
+            </Fragment>
+          ) : null}
           <SectionInfo
             title="Block Height"
             value={

--- a/src/app/swap/[slug]/SwapPage.tsx
+++ b/src/app/swap/[slug]/SwapPage.tsx
@@ -59,7 +59,7 @@ export function SwapPage() {
 
   const {
     data: message,
-    isLoading,
+    // isLoading,
     error,
   } = useQuery({
     enabled: Boolean(messageId) && isValidId,
@@ -171,7 +171,7 @@ export function SwapPage() {
     }
   }, [message])
 
-  if (isLoading) {
+  if (swapLoading) {
     return <LoadingSkeletons />
   }
 

--- a/src/app/swap/[slug]/SwapPage.tsx
+++ b/src/app/swap/[slug]/SwapPage.tsx
@@ -1,36 +1,24 @@
-import { Box, CircularProgress, Paper, Stack, Tabs, Tooltip, Typography } from "@mui/material"
+import { Stack, Tooltip, Typography } from "@mui/material"
 
-import Grid2 from "@mui/material/Unstable_Grid2/Grid2"
-import { MessageResult } from "@permaweb/aoconnect/dist/lib/result"
 import { useQuery } from "@tanstack/react-query"
-import React, { useCallback, useEffect, useMemo, useState } from "react"
+import React, { useEffect, useMemo, useState } from "react"
 
-import { Navigate, useParams, useSearchParams } from "react-router-dom"
+import { useParams } from "react-router-dom"
 
-import { ComputeResult } from "./ComputeResult"
-import { LinkedMessages } from "./LinkedMessages"
-import { MessageData } from "./MessageData"
-import { ResultingMessages } from "./ResultingMessages"
 import { EntityBlock } from "@/components/EntityBlock"
-import { ChartDataItem, Graph } from "@/components/Graph"
 import { IdBlock } from "@/components/IdBlock"
 
 import { LoadingSkeletons } from "@/components/LoadingSkeletons"
 import { SectionInfo } from "@/components/SectionInfo"
-import { SectionInfoWithChip } from "@/components/SectionInfoWithChip"
 import { Subheading } from "@/components/Subheading"
-import { TabWithCount } from "@/components/TabWithCount"
-import { TagsSection } from "@/components/TagsSection"
 
 import { getMessageById, getResultingMessages } from "@/services/messages-api"
 import { AoMessage, Tag } from "@/types"
-import { truncateId } from "@/utils/data-utils"
 import { formatFullDate, formatRelative } from "@/utils/date-utils"
 
 import { formatNumber } from "@/utils/number-utils"
 import { isArweaveId } from "@/utils/utils"
 import { result } from "@permaweb/aoconnect"
-import { prettifyResult } from "@/utils/ao-utils"
 import { TokenAmountSection } from "@/components/TokenAmountSection"
 import { useTokenInfo } from "@/hooks/useTokenInfo"
 
@@ -45,11 +33,26 @@ interface Swap {
   tokenIn: string
   tokenOut: string
   initiator: string
+  lp: string
   amm: string
   quantityIn: string
   quantityOut: string
   feeBps: number
+  totalFee: string
 }
+
+const getResultingMessageByTags = (resultingMessages: any[], tags: [string, string][]) => {
+  return resultingMessages.find((m) => {
+    const { Tags } = m
+    const requiredTags = new Map(tags)
+    return [...requiredTags].every(([key, value]) =>
+      Tags.some(({ name, value: tagValue }: Tag) => name === key && tagValue === value),
+    )
+  })
+}
+
+const getTagValue = (tags: Tag[], tagName: string): string =>
+  tags.find((tag: Tag) => tag.name === tagName)?.value ?? ""
 
 export function SwapPage() {
   const { messageId = "" } = useParams()
@@ -78,29 +81,21 @@ export function SwapPage() {
       // If original message has no Swap tag => not a swap
       if (transferInMessage.tags["X-Action"] !== "Swap")
         throw new Error("Message does not initiate a swap")
-      // A - GET CREDIT NOTICE TO AMM
+      // A - GET CREDIT NOTICE TO LP
       // Get resulting messages from original message
       const { Messages: originalResultingMessages } = await result({
         message: transferInMessage.id,
         process: transferInMessage.to,
       })
-      // Get resulting Credit Notice message from the token in to the AMM
-      const creditNotice = originalResultingMessages.find((m) => {
-        const { Tags } = m
-        const requiredTags = new Map([
-          ["Action", "Credit-Notice"],
-          ["X-Action", "Swap"],
-        ])
-        return [...requiredTags].every(([key, value]) =>
-          Tags.some(({ name, value: tagValue }: Tag) => name === key && tagValue === value),
-        )
-      })
-      // If no credit notice message is sent to the AMM => not a swap
-      if (!creditNotice) throw new Error("No credit notice message sent to AMM")
+      // Get resulting Credit Notice message from the token in to the LP
+      const creditNotice = getResultingMessageByTags(originalResultingMessages, [
+        ["Action", "Credit-Notice"],
+        ["X-Action", "Swap"],
+      ])
+      // If no credit notice message is sent to the LP => not a swap
+      if (!creditNotice) throw new Error("No credit notice message sent to LP")
       // Get credit notice message ID from graph using message ref
-      const { value: creditNoticeRef } = creditNotice.Tags.find(
-        (tag: Tag) => tag.name === "Reference",
-      )
+      const creditNoticeRef = getTagValue(creditNotice.Tags, "Reference")
       const [, [creditNoticeMessage]] = await getResultingMessages(
         1,
         "",
@@ -112,36 +107,34 @@ export function SwapPage() {
       const {
         id: creditNoticeMessageId,
         tags: { Quantity: quantityIn },
-        to: ammProcessId,
+        to: lpProcessId,
       } = creditNoticeMessage
 
       // B - GET TRANSFER TO TOKEN OUT
       // Get resulting messages from credit notice to the AMM
       const { Messages: creditNoticeResultingMessages } = await result({
         message: creditNoticeMessageId,
-        process: ammProcessId,
+        process: lpProcessId,
       })
       // Get resulting Transfer message from the AMM to the token out
-      const transferOut = creditNoticeResultingMessages.find((m) => {
-        const { Tags } = m
-        const requiredTags = new Map([
-          ["Action", "Transfer"],
-          ["X-Action", "Swap-Output"],
-        ])
-        return [...requiredTags].every(([key, value]) =>
-          Tags.some(({ name, value: tagValue }: Tag) => name === key && tagValue === value),
-        )
-      })
+      const transferOut = getResultingMessageByTags(creditNoticeResultingMessages, [
+        ["Action", "Transfer"],
+        ["X-Action", "Swap-Output"],
+      ])
+      // Get resulting Order Confirmation from the pool to the AMM
+      const orderConfirmation = getResultingMessageByTags(creditNoticeResultingMessages, [
+        ["Action", "Order-Confirmation"],
+      ])
+      const totalFee = getTagValue(orderConfirmation.Tags, "Total-Fee")
+
       // If no transfer message is sent from the AMM => not a swap
       if (!transferOut) throw new Error("No transfer message sent from AMM to token out")
-      console.log(`transferOut:`, transferOut)
       // Get transfer message ID from graph using message ref
-      const { value: transferRef } = transferOut.Tags.find((tag: Tag) => tag.name === "Reference")
-      const { value: feeBpsStr } = transferOut.Tags.find((tag: Tag) => tag.name === "X-Fee-Bps")
-      const [, [transferOutMessage]] = await getResultingMessages(1, "", true, "", ammProcessId, [
+      const transferRef = getTagValue(transferOut.Tags, "Reference")
+      const feeBpsStr = getTagValue(transferOut.Tags, "X-Fee-Bps")
+      const [, [transferOutMessage]] = await getResultingMessages(1, "", true, "", lpProcessId, [
         transferRef,
       ])
-      console.log(`transferOutMessage:`, transferOutMessage)
       const {
         id: transferOutMessageId,
         tags: { Quantity: quantityOut },
@@ -157,12 +150,13 @@ export function SwapPage() {
         tokenIn: transferInMessage.to,
         tokenOut,
         initiator: transferInMessage.from,
-        amm: ammProcessId,
+        lp: lpProcessId,
+        amm: orderConfirmation.Target,
         quantityIn,
         quantityOut,
-        feeBps: Number(feeBpsStr)
+        feeBps: Number(feeBpsStr),
+        totalFee,
       }
-      console.log(`data:`, data)
 
       setSwapData(data)
     } catch (e) {
@@ -174,7 +168,6 @@ export function SwapPage() {
 
   useEffect(() => {
     if (!!message) {
-      console.log(`message:`, message)
       getSwap(message)
     }
   }, [message])
@@ -200,10 +193,12 @@ export function SwapPage() {
     tokenIn,
     tokenOut,
     initiator,
+    lp,
     amm,
     quantityIn,
     quantityOut,
     feeBps,
+    totalFee,
   } = swapData
 
   return (
@@ -213,20 +208,20 @@ export function SwapPage() {
         <Stack gap={4}>
           <SectionInfo title="Swapper" value={<EntityBlock entityId={initiator} />} />
           <SectionInfo title="AMM" value={<EntityBlock entityId={amm} />} />
+          <SectionInfo title="Liquidity Pool" value={<EntityBlock entityId={lp} />} />
           <SectionInfo title="Token In" value={<EntityBlock entityId={tokenIn} />} />
           <SectionInfo title="Token Out" value={<EntityBlock entityId={tokenOut} />} />
           <SectionInfo
             title="Fee"
             value={
-
-                <Tooltip title={`${feeBps} bps`}>
-                  <span>{feeBps * 0.01}%</span>
-                </Tooltip>
-              
+              <Tooltip title={`${feeBps} bps`}>
+                <span>{feeBps * 0.01}%</span>
+              </Tooltip>
             }
           />
           <TokenAmountSection tokenInfo={tokenInInfo} amount={quantityIn} label="Quantity In" />
           <TokenAmountSection tokenInfo={tokenOutInfo} amount={quantityOut} label="Quantity Out" />
+          <TokenAmountSection tokenInfo={tokenInInfo} amount={totalFee} label="Total Fee" />
           <SectionInfo
             title="Block Height"
             value={

--- a/src/components/TokenAmountSection.tsx
+++ b/src/components/TokenAmountSection.tsx
@@ -1,0 +1,46 @@
+import { Avatar, Stack } from "@mui/material"
+import React from "react"
+
+import { truncateId } from "@/utils/data-utils"
+import { nativeTokenInfo } from "@/utils/native-token"
+
+import { IdBlock } from "./IdBlock"
+import { RetryableBalance } from "./RetryableBalance"
+import { SectionInfo } from "./SectionInfo"
+import { TokenAmountBlock } from "./TokenAmountBlock"
+import { TokenInfo } from "@/services/token-api"
+
+type TokenAmountSectionProps = {
+  amount: string
+  tokenInfo: TokenInfo | null | undefined
+  label: string
+}
+
+export function TokenAmountSection(props: TokenAmountSectionProps) {
+  const { amount, label, tokenInfo } = props
+
+  const tokenId = tokenInfo?.processId ?? "";
+
+  return (
+    <SectionInfo
+      title={label}
+      value={
+        <Stack direction="row" gap={1} alignItems="center">
+          <TokenAmountBlock amount={amount} tokenInfo={tokenInfo} needsParsing />
+          {tokenInfo && (
+            <Avatar
+              src={`https://arweave.net/${tokenInfo.logo}`}
+              alt={tokenInfo.name}
+              sx={{ width: 16, height: 16 }}
+            />
+          )}
+          <IdBlock
+            label={tokenInfo?.ticker || truncateId(tokenId)}
+            value={tokenId}
+            href={`/token/${tokenId}`}
+          />
+        </Stack>
+      }
+    />
+  )
+}

--- a/src/components/TokenAmountSection.tsx
+++ b/src/components/TokenAmountSection.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Stack } from "@mui/material"
+import { Avatar, Skeleton, Stack } from "@mui/material"
 import React from "react"
 
 import { truncateId } from "@/utils/data-utils"
@@ -14,19 +14,24 @@ type TokenAmountSectionProps = {
   amount: string
   tokenInfo: TokenInfo | null | undefined
   label: string
+  loading?: boolean
 }
 
 export function TokenAmountSection(props: TokenAmountSectionProps) {
-  const { amount, label, tokenInfo } = props
+  const { amount, label, tokenInfo, loading } = props
 
-  const tokenId = tokenInfo?.processId ?? "";
+  const tokenId = tokenInfo?.processId ?? ""
 
   return (
     <SectionInfo
       title={label}
       value={
         <Stack direction="row" gap={1} alignItems="center">
-          <TokenAmountBlock amount={amount} tokenInfo={tokenInfo} needsParsing />
+          {!loading ? (
+            <TokenAmountBlock amount={amount} tokenInfo={tokenInfo} needsParsing />
+          ) : (
+            <Skeleton width={50} sx={{ display: "inline-flex" }} height={22} />
+          )}
           {tokenInfo && (
             <Avatar
               src={`https://arweave.net/${tokenInfo.logo}`}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,6 +26,7 @@ import ProcessesPage from "./app/processes/ProcessesPage"
 import TokenPage from "./app/token/[slug]/TokenPage"
 import RootLayoutUI from "./components/RootLayout/RootLayoutUI"
 import { FourZeroFourPage } from "./pages/404"
+import { SwapPage } from "./app/swap/[slug]/SwapPage"
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <HashRouter>
@@ -33,6 +34,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
       <Routes>
         <Route path="/" element={<HomePage />} />
         <Route path="/message/:messageId" element={<MessagePage />} />
+        <Route path="/swap/:messageId" element={<SwapPage />} />
         <Route path="/blocks" element={<BlocksPage />} />
         <Route path="/block/:blockHeight" element={<BlockPage />} />
         <Route path="/modules" element={<ModulesPage />} />


### PR DESCRIPTION
**Change summary**
Created a page on the /swap/:messageId route. In this route, the `messageId` param represents the ID of the Transfer message initiating a swap.

This page is meant to fetch and display the relevant data of an entire swap if successful, or the swap error (with the failing message) if unsuccessful.

The main method of this page is getSwap, which takes the initial Transfer message and, based on the data it contains, fetches the following messages (e.g. Credit Notice etc.) of the swap, using the async calls `result` and `getResultingMessages`. The getSwap method sets and updates the `swapData` state, which follows the `Swap` type, storing many relevant data about the overall swap. The list of attributes is not yet exhaustive and can be expanded.

```TS
interface Swap {
  blockHeight: number | null
  ingestedAt: Date
  transferInMessageId: string
  tokenIn: string
  lp: string
  tokenOut: string
  initiator: string
  ammFactory: string
  quantityIn: string
  feeBps: number
  quantityOut?: string
  CreditNoticeTokenInMessageId?: string
  transferOutMessageId?: string
  totalFee?: string
}
```

If an error occurs at any point during the swap (i.e. any message fails), getSwap is terminated and the failing message is stored in the `failingMessage` state.

If the messageId param is found not to match a message initiating a swap, an error message is displayed.

In the Swap type, all non-optional attributes are set from the data obtained through the initial Transfer message as well as the LP process. The optional attributes are obtained by fetching the following messages. Thus is the swap fails after the initial Transfer message, the optional attributes will not be displayed in the UI.

The UI lists all available swap attributes, as well as the failing message if the swap is failing.

**Areas for improvements**
A graph can be used to display to message sequence for the swap, whether full (success) or partial (failure).

**Concerns**
The `getSwap` method detects errors through the return value of the `result` method. This return value is of type `MessageResult` which has an optional attribute Error (capital case). However, it can happen that `result` return an `error` (lowercase) attribute which is not included in the `MessageResult` type. This issue is in the @permaweb/aoconnect package.

